### PR TITLE
Add more permissions to RBAC, make Ingress reference by name

### DIFF
--- a/clusterRole/nelson.yaml
+++ b/clusterRole/nelson.yaml
@@ -4,5 +4,5 @@ metadata:
   name: nelson
 rules:
   - apiGroups: ["", "apps", "batch"]
-    resources: ["deployments", "deployments/status", "cronjobs", "cronjobs/status", "jobs", "jobs/status"]
+    resources: ["deployments", "deployments/status", "services", "services/status", "pods", "pods/status", "cronjobs", "cronjobs/status", "jobs", "jobs/status"]
     verbs:     ["*"]

--- a/ingress/nelson.yaml
+++ b/ingress/nelson.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   backend:
     serviceName: nelson
-    servicePort: 9000
+    servicePort: api


### PR DESCRIPTION
New RBAC permissions needed to create Kubernetes Service and get Pod
status for health checks.